### PR TITLE
Updated readme, added .travis.yml, added ability to create states without specifying type.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: csharp
+solution: Fluent-State-Machine.sln
+ 
+install:
+  - nuget restore Fluent-State-Machine.sln
+  - nuget install xunit.runners -Version 1.9.2 -OutputDirectory testrunner
+ 
+script:
+  - xbuild /p:Configuration=Debug Fluent-State-Machine.sln
+  - mono ./testrunner/xunit.runners.1.9.2/tools/xunit.console.exe ./Tests/bin/Debug/Fluent-State-Machine.Tests.dll

--- a/README.md
+++ b/README.md
@@ -240,3 +240,16 @@ same state can have the same name, this can only be done once per type of state 
             .End()
         .End()
         .Build();
+        
+## Examples
+
+In the `Examples` directory there are a couple of example projects to demonstrate usage of the library.
+
+### Example 1
+
+This sample demonstrates a fairly simple state machine with custom nested states, from a console app.
+
+### Unity Example
+
+This sample comes as a Unity project and shows how one could set up the library for use in a Unity 
+game, as well as using *events* to trigger actions in response to Unity physics collision events. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # Fluent-State-Machine  [![Build Status](https://travis-ci.org/Real-Serious-Games/Fluent-State-Machine.svg)](https://travis-ci.org/Real-Serious-Games/Fluent-State-Machine) #
 Fluent API for creating [hierarchical finite state machines](http://aigamedev.com/open/article/hfsm-gist/) in C#.
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [A basic example - creating a state machine with a single state](#a-basic-example---creating-a-state-machine-with-a-single-state)
+- [Conditions](#conditions)
+- [Using multiple states](#using-multiple-states)
+- [Nesting states](#nesting-states)
+- [Pushing and popping nested states](#pushing-and-popping-nested-states)
+- [Events](#events)
+- [Custom states](#custom-states)
+- [Examples](#examples)
+  - [Example 1](#example-1)
+  - [Unity Example](#unity-example)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## A basic example - creating a state machine with a single state
 
 Reference the dll and include the namespace:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,242 @@
-# Fluent-State-Machine
-Fluent API for creating state machines in C#
+# Fluent-State-Machine  [![Build Status](https://travis-ci.org/Real-Serious-Games/Fluent-State-Machine.svg)](https://travis-ci.org/Real-Serious-Games/Fluent-State-Machine) #
+Fluent API for creating [hierarchical finite state machines](http://aigamedev.com/open/article/hfsm-gist/) in C#.
+
+## A basic example - creating a state machine with a single state
+
+Reference the dll and include the namespace:
+
+    using RSG;
+    
+Create a state via the builder class:
+
+    var rootState = new StateMachineBuilder()
+        .State("main")
+            .Enter(state => {
+                Console.WriteLine("Entered main state");
+            })
+            .Update((state, deltaTime) => {
+                Console.WriteLine("Updating main state");
+            })
+        .End()
+        .Build();
+        
+Calling `Build()` on our StateMachineBuilder sets up all the states we've specified and returns a root
+state which is automatically created to be the parent of any top-level states we create. 
+
+The function in `Enter` will be called once when we first enter the state, and the function in `Update`
+will be called every time we update the state.
+
+Once our state machine is set up, we then need to set the initial state:
+
+    rootState.ChangeState("main");
+    
+Finally, we can update our currently active state with a specified time since the last update as follows:
+
+    rootState.Update(timeSinceLastFrame); 
+    
+## Conditions 
+
+As well as Enter and Update, conditions can be set up, which are functions called when the state is
+updated only when a specified predicate is satisfied.
+
+    var rootState = new StateMachineBuilder()
+        .State("main")
+            .Enter(state => {
+                Console.WriteLine("Entered main state");
+            })
+            .Update((state, deltaTime) => {
+                Console.WriteLine("Updating main state");
+            })
+            .Condition(() => SomeBoolean, state => {
+                Console.WriteLine("Condition satisfied");
+            })
+        .End()
+        .Build();
+        
+The predicate to the condition is also a function, and this function will be invoked every time the state
+is updated.
+
+## Using multiple states
+
+Switch between states by using `IState.ChangeState(stateName)` 
+
+    var rootState = new StateMachineBuilder()
+        .State("main")
+            .Enter(state => {
+                Console.WriteLine("Entered main state");
+            })
+            .Update((state, deltaTime) => {
+                Console.WriteLine("Updating main state");
+            })
+            .Condition(() => SomeBoolean, state => {
+                state.Parent.ChangeState("secondary");
+            })
+            .Exit(state => {
+                Console.WriteLine("Exited main state");
+            })
+        .End()
+        .State("secondary")
+            .Enter(state => {
+                Console.WriteLine("Entered secondary state")
+            })
+        .End()
+        .Build();
+        
+`ChangeState` will attempt to exit the current state and change to the specified one. Note that since
+both our "main" state and "secondary" states are children of the root state, we actually need to call
+ChangeState on the main state's parent (which in this case is the root state). 
+
+The function specified in `Exit` will be called when we exit the main state.
+
+## Nesting states
+
+Nested states, sometimes referred to as *super-states* are useful for encapsulating different parts of
+logic and simplifying transitions between states.
+
+    var rootState = new StateMachineBuilder()
+        .State("main")
+            .Enter(state => {
+                Console.WriteLine("Entered main state");
+            })
+            .Update((state, deltaTime) => {
+                Console.WriteLine("Updating main state");
+            })
+            .Condition(() => SomeBoolean, state => {
+                state.ChangeState("child");
+            })
+            .Exit(state => {
+                Console.WriteLine("Exited main state");
+            })
+            .State("child")
+                .Enter(state => {
+                    Console.WriteLine("Entered secondary state")
+                })
+            .End()
+        .End()
+        .Build();
+
+Our second state is now a child of the main state. This example doesn't really add any extra 
+functionality but serves to show how a nesting can work in its most basic form. Note that `Exit` is
+not called on the main state when we change to it even though it is no longer being updated, since
+it is still technically active but only the end of the tree is updated.
+
+## Pushing and popping nested states
+
+In addition to a list of children, each state contains a stack of active children
+
+    var rootState = new StateMachineBuilder()
+        .State("main")
+            .Enter(state => {
+                Console.WriteLine("Entered main state");
+            })
+            .Update((state, deltaTime) => {
+                Console.WriteLine("Updating main state");
+            })
+            .Condition(() => SomeBoolean, state => {
+                state.PushState("firstChild");
+            })
+            .Exit(state => {
+                Console.WriteLine("Exited main state");
+            })
+            .State("firstChild")
+                .Enter(state => {
+                    Console.WriteLine("Entered secondary state")
+                })
+                .Condition(() => SomeBoolean, state => {
+                    state.Parent.PushState("secondChild");
+                })
+            .End()
+            .State("secondChild")
+                .Enter(state => {
+                    Console.WriteLine("Entered third child state")
+                })
+                .Condition(() => ShouldPopState, state => {
+                    state.Parent.PopState();
+                })
+            .End()
+        .End()
+        .Build();
+
+In this example, we will start out in `main`, then when `SomeBoolean` is true we'll go to `firstChild`.
+If `SomeBoolean` is still true we will transition to `secondChild`, and then when `ShouldPopState` is
+true we will go back the previous state on the stack (in this case `firstChild`). 
+
+## Events
+
+The state builder doesn't give us a reference to the new states it creates, but if we want to trigger 
+an action on the currently active state that we don't want to run every frame (like a *condition*)
+we can use an *event*.
+
+    var rootState = new StateMachineBuilder()
+        .State("main")
+            .Enter(state => {
+                Console.WriteLine("Entered main state");
+            })
+            .Update((state, deltaTime) => {
+                Console.WriteLine("Updating main state");
+            })
+            .Condition(() => SomeBoolean, state => {
+                state.ChangeState("child");
+            })
+            .State("child")
+                .Enter(state => {
+                    Console.WriteLine("Entered secondary state")
+                })
+                .Event("MyEvent", state => {
+                    Console.WriteLine("MyEvent triggered");
+                });
+            .End()
+        .End()
+        .Build();
+
+Invoking the event on the root state will trigger it on whatever the currently active state is:
+
+    rootState.TriggerEvent("MyEvent"); 
+
+## Custom states
+
+Sometimes we will want to have data shared by the Enter, Update, Condition, Event and Exit functions
+of a state, specific to that state, or we might want to have some methods that are internal to just
+that state. This an be achieved by creating a sub-class of `AbstractState` that has our extra 
+functionality in it, and specifying this when we create the state.
+
+    class MainState : AbstractState
+    {
+        public string updateMessage = "Updating main state";
+        
+        public void PushChildState()
+        {
+            PushState("child");
+        }
+    }
+    
+Note that since this class inherits from AbstractState, it has full access to methods for pushing, 
+popping and changing states. Since this will be newed-up by the state builder it must have either
+no constructor or a parameterless constructor.
+
+Setting up the state is basically the same as it would otherwise be except that we now also specify
+the type of the state. The name field is now optional since the builder can just automatically take 
+the name from the name of the class it uses, although since no two states that are children of the
+same state can have the same name, this can only be done once per type of state for each group.
+
+    var rootState = new StateMachineBuilder()
+        .State<MainState>()
+            .Enter(state => {
+                Console.WriteLine("Entered main state");
+            })
+            .Update((state, deltaTime) => {
+                Console.WriteLine(state.updateMessage);
+            })
+            .Condition(() => SomeBoolean, state => {
+                state.PushChildState();
+            })
+            .State("child")
+                .Enter(state => {
+                    Console.WriteLine("Entered secondary state")
+                })
+                .Event("MyEvent", state => {
+                    Console.WriteLine("MyEvent triggered");
+                });
+            .End()
+        .End()
+        .Build();

--- a/State.cs
+++ b/State.cs
@@ -50,7 +50,17 @@ namespace RSG
         /// <summary>
         /// Trigger an event on this state or one of its children.
         /// </summary>
+        /// <param name="name">Name of the event to trigger</param>
         void TriggerEvent(string name);
+
+        /// <summary>
+        /// Triggered when and event occurs. Executes the event's action if the 
+        /// current state is at the top of the stack, otherwise triggers it on 
+        /// the next state down.
+        /// </summary>
+        /// <param name="name">Name of the event to trigger</param>
+        /// <param name="eventArgs">Arguments to send to the event</param>
+        void TriggerEvent(string name, EventArgs eventArgs);
     }
 
     /// <summary>
@@ -307,7 +317,7 @@ namespace RSG
             // Only update the child at the end of the tree
             if (activeChildren.Any())
             {
-                activeChildren.Peek().TriggerEvent(name);
+                activeChildren.Peek().TriggerEvent(name, eventArgs);
                 return;
             }
 

--- a/State.cs
+++ b/State.cs
@@ -289,7 +289,20 @@ namespace RSG
         /// current state is at the top of the stack, otherwise triggers it on 
         /// the next state down.
         /// </summary>
+        /// <param name="name">Name of the event to trigger</param>
         public void TriggerEvent(string name)
+        {
+            TriggerEvent(name, null);
+        }
+
+        /// <summary>
+        /// Triggered when and event occurs. Executes the event's action if the 
+        /// current state is at the top of the stack, otherwise triggers it on 
+        /// the next state down.
+        /// </summary>
+        /// <param name="name">Name of the event to trigger</param>
+        /// <param name="eventArgs">Arguments to send to the event</param>
+        public void TriggerEvent(string name, EventArgs eventArgs)
         {
             // Only update the child at the end of the tree
             if (activeChildren.Any())
@@ -301,13 +314,8 @@ namespace RSG
             Action<EventArgs> myEvent;
             if (events.TryGetValue(name, out myEvent))
             {
-                myEvent(null);
+                myEvent(eventArgs);
             }
-        }
-
-        public void TriggerEvent(string name, EventArgs eventArgs)
-        {
-            throw new NotImplementedException();
         }
     }
 

--- a/State.cs
+++ b/State.cs
@@ -93,7 +93,7 @@ namespace RSG
         /// <summary>
         /// Dictionary of all actions associated with this state.
         /// </summary>
-        private IDictionary<string, Action> events = new Dictionary<string, Action>();
+        private IDictionary<string, Action<EventArgs>> events = new Dictionary<string, Action<EventArgs>>();
 
         /// <summary>
         /// Pops the current state from the stack and pushes the specified one on.
@@ -252,7 +252,7 @@ namespace RSG
         /// Sets an action to be associated with an identifier that can later be used
         /// to trigger it.
         /// </summary>
-        public void SetEvent(string identifier, Action eventTriggeredAction)
+        public void SetEvent(string identifier, Action<EventArgs> eventTriggeredAction)
         {
             events.Add(identifier, eventTriggeredAction);
         }
@@ -298,11 +298,16 @@ namespace RSG
                 return;
             }
 
-            Action myEvent;
+            Action<EventArgs> myEvent;
             if (events.TryGetValue(name, out myEvent))
             {
-                myEvent();
+                myEvent(null);
             }
+        }
+
+        public void TriggerEvent(string name, EventArgs eventArgs)
+        {
+            throw new NotImplementedException();
         }
     }
 

--- a/StateBuilder.cs
+++ b/StateBuilder.cs
@@ -60,6 +60,15 @@ namespace RSG
         IStateBuilder<T, TParent> Event(string identifier, Action<T> action);
 
         /// <summary>
+        /// Set an action with arguments to be triggerable when an event with the specified name is raised.
+        /// </summary>
+        /// <typeparam name="TEvent"></typeparam>
+        /// <param name="identifier"></param>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        IStateBuilder<T, TParent> Event<TEvent>(string identifier, Action<T, TEvent> action) where TEvent : EventArgs;
+
+        /// <summary>
         /// Finalise the current state and return the builder for its parent.
         /// </summary>
         TParent End();

--- a/StateBuilder.cs
+++ b/StateBuilder.cs
@@ -28,6 +28,13 @@ namespace RSG
         IStateBuilder<NewStateT, IStateBuilder<T, TParent>> State<NewStateT>(string name) where NewStateT : AbstractState, new();
 
         /// <summary>
+        /// Create a child state with the default handler type.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns>A state builder object for the new child state</returns>
+        IStateBuilder<State, IStateBuilder<T, TParent>> State(string name);
+
+        /// <summary>
         /// Set an action to be called when we enter the state.
         /// </summary>
         IStateBuilder<T, TParent> Enter(Action<T> onEnter);
@@ -127,6 +134,16 @@ namespace RSG
             where NewStateT : AbstractState, new()
         {
             return new StateBuilder<NewStateT, IStateBuilder<T, TParent>>(this, state, name);
+        }
+
+        /// <summary>
+        /// Create a child state with the default handler type.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns>A state builder object for the new child state</returns>
+        public IStateBuilder<State, IStateBuilder<T, TParent>> State(string name)
+        {
+            return new StateBuilder<State, IStateBuilder<T, TParent>>(this, state, name);
         }
 
         /// <summary>

--- a/StateBuilder.cs
+++ b/StateBuilder.cs
@@ -191,7 +191,17 @@ namespace RSG
         /// </summary>
         public IStateBuilder<T, TParent> Event(string identifier, Action<T> action)
         {
-            state.SetEvent(identifier, () => action(state));
+            state.SetEvent(identifier, _ => action(state));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Set an action with arguments to be triggerable when an event with the specified name is raised.
+        /// </summary>
+        public IStateBuilder<T, TParent> Event<TEvent>(string identifier, Action<T, TEvent> action) where TEvent : EventArgs
+        {
+            state.SetEvent(identifier, args => action(state, (TEvent)args));
 
             return this;
         }

--- a/StateMachineBuilder.cs
+++ b/StateMachineBuilder.cs
@@ -46,6 +46,17 @@ namespace RSG
         }
 
         /// <summary>
+        /// Create a new state with a specified name and add it as a
+        /// child of the root state.
+        /// </summary>
+        /// <param name="stateName">Name for the new state</param>
+        /// <returns>Builder used to configure the new state</returns>
+        public IStateBuilder<State, StateMachineBuilder> State(string stateName)
+        {
+            return new StateBuilder<State, StateMachineBuilder>(this, rootState, stateName);
+        }
+
+        /// <summary>
         /// Return the root state once everything has been set up.
         /// </summary>
         public IState Build()

--- a/Tests/StateBuilderTests.cs
+++ b/Tests/StateBuilderTests.cs
@@ -12,7 +12,7 @@ namespace RSG.FluentStateMachineTests
         private class TestState : AbstractState { }
 
         [Fact]
-        public void state_adds_state_as_child_of_current_state()
+        public void state_with_type_adds_state_as_child_of_current_state()
         {
             IState expectedParent = null;
             IState actualParent = null;
@@ -35,7 +35,7 @@ namespace RSG.FluentStateMachineTests
         }
 
         [Fact]
-        public void named_state_is_added_with_correct_name()
+        public void named_state_with_type_is_added_with_correct_name()
         {
             IState expectedParent = null;
             IState actualParent = null;
@@ -47,6 +47,29 @@ namespace RSG.FluentStateMachineTests
                         state.ChangeState("bar");
                     })
                     .State<TestState>("bar")
+                        .Enter(state => actualParent = state.Parent)
+                    .End()
+                .End()
+                .Build();
+
+            rootState.ChangeState("foo");
+
+            Assert.Equal(expectedParent, actualParent);
+        }
+
+        [Fact]
+        public void state_adds_state_as_child_of_current_state()
+        {
+            IState expectedParent = null;
+            IState actualParent = null;
+
+            var rootState = new StateMachineBuilder()
+                .State<TestState>("foo")
+                    .Enter(state => {
+                        expectedParent = state;
+                        state.ChangeState("bar");
+                    })
+                    .State("bar")
                         .Enter(state => actualParent = state.Parent)
                     .End()
                 .End()

--- a/Tests/StateBuilderTests.cs
+++ b/Tests/StateBuilderTests.cs
@@ -11,6 +11,11 @@ namespace RSG.FluentStateMachineTests
     {
         private class TestState : AbstractState { }
 
+        class TestEventArgs : EventArgs
+        {
+            public string TestString { get; set; }
+        }
+
         [Fact]
         public void state_with_type_adds_state_as_child_of_current_state()
         {
@@ -170,6 +175,27 @@ namespace RSG.FluentStateMachineTests
             rootState.TriggerEvent("newEvent");
 
             Assert.Equal(1, timesEventRaised);
+        }
+
+        [Fact]
+        public void event_passes_correct_arguments()
+        {
+            var expectedString = "test";
+            var actualString = string.Empty;
+
+            var testEventArgs = new TestEventArgs();
+            testEventArgs.TestString = expectedString;
+
+            var rootState = new StateMachineBuilder()
+                .State<TestState>("foo")
+                    .Event<TestEventArgs>("newEvent", (state, eventArgs) => actualString = eventArgs.TestString)
+                .End()
+                .Build();
+            rootState.ChangeState("foo");
+
+            rootState.TriggerEvent("newEvent", testEventArgs);
+
+            Assert.Equal(expectedString, actualString);
         }
     }
 }

--- a/Tests/StateMachineBuilderTests.cs
+++ b/Tests/StateMachineBuilderTests.cs
@@ -27,12 +27,28 @@ namespace RSG.FluentStateMachineTests
         }
 
         [Fact]
-        public void state_with_string_has_specified_name()
+        public void state_with_type_and_string_has_specified_name()
         {
             IState expectedParent = null;
 
             var rootState = new StateMachineBuilder()
                 .State<TestState>("test")
+                    .Enter(state => expectedParent = state.Parent)
+                .End()
+                .Build();
+
+            rootState.ChangeState("test");
+
+            Assert.Equal(rootState, expectedParent);
+        }
+
+        [Fact]
+        public void state_with_string_has_specified_name()
+        {
+            IState expectedParent = null;
+
+            var rootState = new StateMachineBuilder()
+                .State("test")
                     .Enter(state => expectedParent = state.Parent)
                 .End()
                 .Build();

--- a/Tests/StateTests.cs
+++ b/Tests/StateTests.cs
@@ -440,7 +440,7 @@ namespace RSG.FluentStateMachineTests
             rootState.PopState();
             rootState.TriggerEvent("someEvent");
 
-            mockState.Verify(state => state.TriggerEvent(It.IsAny<String>()), Times.Once());
+            mockState.Verify(state => state.TriggerEvent(It.IsAny<String>(), It.IsAny<EventArgs>()), Times.Once());
         }
 
         [Fact]
@@ -463,7 +463,7 @@ namespace RSG.FluentStateMachineTests
         }
 
         [Fact]
-        public void event_args_are_passed_on_to_event()
+        public void event_args_are_passed_on_to_child_event()
         {
             var rootState = CreateTestState();
 
@@ -473,11 +473,16 @@ namespace RSG.FluentStateMachineTests
             var testEventArgs = new TestEventArgs();
             testEventArgs.TestString = expectedString;
 
-            rootState.SetEvent("foo", eventArgs => {
+            var childState = CreateTestState();
+            rootState.AddChild(childState, "Child");
+
+            childState.SetEvent("foo", eventArgs => {
                 var actualEventArgs = (TestEventArgs)eventArgs;
 
                 actualString = actualEventArgs.TestString;
             });
+
+            rootState.PushState("Child");
 
             rootState.TriggerEvent("foo", testEventArgs);
 


### PR DESCRIPTION
Readme now contains usage examples and descripts of all main features.

Added Travis CI build config for building and running unit tests.

Added a new method on the state builder that allows creating a state without specifying a type. This uses the default `State` type.

Events can now be passed an object of type EventArgs in order to pass data through to the event.